### PR TITLE
SKDMAN ENV to set default environment tools version

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,5 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=17.0.8-amzn
+quarkus=3.3.3
+maven=3.9.4


### PR DESCRIPTION
Using SDK Env to easy switch to project default tools version.

To install the tools:
```
sdk env install
```

If you already have installed before:
```
sdk env
```

After you execute the command your environment is ready to go!


Default tools and versions
JAVA = 17.0.8-amzn
MAVEN = 3.9.4
QUARKUS = 3.3.3
